### PR TITLE
Add: DeletedEntity 추가

### DIFF
--- a/src/main/java/com/example/dm/aspect/CustomRequestWrapper.java
+++ b/src/main/java/com/example/dm/aspect/CustomRequestWrapper.java
@@ -42,7 +42,7 @@ public class CustomRequestWrapper extends HttpServletRequestWrapper {
      * 공통 Request 로그 작성
      */
     private void writeRequestLogs(HttpServletRequest request, String requestBody) {
-        String requestId = (String) request.getAttribute("requestId");
+        String txid = (String) request.getAttribute("txid");
         String publicIp = (String) request.getAttribute("publicIp");
         String userAgent = request.getHeader("user-agent");
         String requestMethod = request.getMethod();
@@ -50,11 +50,11 @@ public class CustomRequestWrapper extends HttpServletRequestWrapper {
         String queryString = !Strings.isEmpty(request.getQueryString()) ? "?" + request.getQueryString() : "";
 
         log.info("-------------------------------------");
-        log.info("[Request] => {}", requestId);
-        log.info("{} {} {}", requestId, requestMethod, servletPath + queryString);
-        log.info("{} public ip:{}", requestId, publicIp);
-        log.info("{} user-agent:{}", requestId, userAgent);
-        log.info("{} request body=[{}]", requestId, requestBody);
+        log.info("[Request] => {}", txid);
+        log.info("{} {} {}", txid, requestMethod, servletPath + queryString);
+        log.info("{} public ip:{}", txid, publicIp);
+        log.info("{} user-agent:{}", txid, userAgent);
+        log.info("{} request body=[{}]", txid, requestBody);
     }
 
     @Override

--- a/src/main/java/com/example/dm/aspect/LoggingFilter.java
+++ b/src/main/java/com/example/dm/aspect/LoggingFilter.java
@@ -25,8 +25,8 @@ public class LoggingFilter implements Filter {
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
 
-        // requestId 및 IP 셋팅
-        initRequestId((HttpServletRequest) request);
+        // txid 및 IP 셋팅
+        initTxid((HttpServletRequest) request);
         initPublicIp((HttpServletRequest) request);
 
         CustomRequestWrapper requestWrapper = new CustomRequestWrapper((HttpServletRequest) request);
@@ -43,7 +43,7 @@ public class LoggingFilter implements Filter {
      * 메소드 실행 후 Response 로그 작성
      */
     private void writeResponseLogs(HttpServletRequest request, HttpServletResponse response, String responseBody, StopWatch stopWatch) {
-        String requestId = (String) request.getAttribute("requestId");
+        String txid = (String) request.getAttribute("txid");
         String requestMethod = request.getMethod();
         String servletPath = request.getServletPath();
         String queryString = !Strings.isEmpty(request.getQueryString()) ? "?" + request.getQueryString() : "";
@@ -51,26 +51,26 @@ public class LoggingFilter implements Filter {
 
         if (statusCode >= 400) { // 오류
             log.error("-------------------------------------");
-            log.error("[Response] => {}", requestId);
-            log.error("{} [Exception] {} {} {}", requestId, statusCode, requestMethod, servletPath + queryString);
-            log.error("{} response body=[{}]", requestId, responseBody);
+            log.error("[Response] => {}", txid);
+            log.error("{} [Exception] {} {} {}", txid, statusCode, requestMethod, servletPath + queryString);
+            log.error("{} response body=[{}]", txid, responseBody);
 
         } else { // 성공
             log.info("-------------------------------------");
-            log.info("[Response] => {}", requestId);
-            log.info("{} [Success] {} {} {}", requestId, statusCode, requestMethod, servletPath + queryString);
-            log.info("{} response body=[{}]", requestId, responseBody);
+            log.info("[Response] => {}", txid);
+            log.info("{} [Success] {} {} {}", txid, statusCode, requestMethod, servletPath + queryString);
+            log.info("{} response body=[{}]", txid, responseBody);
         }
 
         stopWatch.stop();
         long durationMs = stopWatch.getTotalTimeMillis();
 
-        log.info("{} duration time:{}ms", requestId, durationMs);
+        log.info("{} duration time:{}ms", txid, durationMs);
         log.info("-------------------------------------");
     }
 
-    private void initRequestId(HttpServletRequest request) {
-        request.setAttribute("requestId", txidGenerator.getTxid());
+    private void initTxid(HttpServletRequest request) {
+        request.setAttribute("txid", txidGenerator.getTxid());
     }
 
     private void initPublicIp(HttpServletRequest request) {

--- a/src/main/java/com/example/dm/entity/DeletedEntity.java
+++ b/src/main/java/com/example/dm/entity/DeletedEntity.java
@@ -1,0 +1,36 @@
+package com.example.dm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+@MappedSuperclass
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class DeletedEntity extends BaseTimeEntity {
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
+
+    @ColumnDefault("false")
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    // Soft Delete 처리
+    public void delete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/example/dm/entity/Images.java
+++ b/src/main/java/com/example/dm/entity/Images.java
@@ -5,12 +5,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
@@ -18,22 +16,19 @@ import org.hibernate.annotations.DynamicInsert;
 @Setter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Images extends BaseTimeEntity {
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  private Long id;
-  private String url;
-  private ImageType type;
-  private Long referenceId;
-  @ColumnDefault("false")
-  private boolean isDeleted = false;
-  private LocalDateTime deletedAt;
+public class Images extends DeletedEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String url;
+    private ImageType type;
+    private Long referenceId;
 
-  public static Images create(String url, ImageType type, Long referenceId){
-    Images images = new Images();
-    images.setUrl(url);
-    images.setType(type);
-    images.setReferenceId(referenceId);
-    return images;
-  }
+    public static Images create(String url, ImageType type, Long referenceId) {
+        Images images = new Images();
+        images.setUrl(url);
+        images.setType(type);
+        images.setReferenceId(referenceId);
+        return images;
+    }
 }

--- a/src/main/java/com/example/dm/entity/UserProfiles.java
+++ b/src/main/java/com/example/dm/entity/UserProfiles.java
@@ -1,20 +1,11 @@
 package com.example.dm.entity;
 
 import com.example.dm.dto.form.SignupForm;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
@@ -22,51 +13,47 @@ import org.hibernate.annotations.DynamicInsert;
 @Setter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserProfiles extends BaseTimeEntity {
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  private Long id;
+public class UserProfiles extends DeletedEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name="id")
-  private Users users;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id")
+    private Users users;
 
-  private Long imageId;
+    private Long imageId;
 
-  @Column(length = 20)
-  private String nickname;
+    @Column(length = 20)
+    private String nickname;
 
-  @Column(length = 20)
-  private String city;
-  @Column(length = 20)
-  private String state;
-  @Column(length = 20)
-  private String street;
+    @Column(length = 20)
+    private String city;
+    @Column(length = 20)
+    private String state;
+    @Column(length = 20)
+    private String street;
 
-  private Double latitude;
-  private Double longitude;
+    private Double latitude;
+    private Double longitude;
 
-  private String introduce;
-  private String url;
-  @Column(length = 50)
-  private String urlName;
+    private String introduce;
+    private String url;
+    @Column(length = 50)
+    private String urlName;
 
-  @ColumnDefault("false")
-  private boolean isDeleted = false;
-  private LocalDateTime deletedAt;
-
-  public static UserProfiles create(Users users, SignupForm signupForm){
-    UserProfiles userProfiles = new UserProfiles();
-    userProfiles.setUsers(users);
-    userProfiles.setNickname(signupForm.getNickname());
-    userProfiles.setCity(signupForm.getCity());
-    userProfiles.setState(signupForm.getState());
-    userProfiles.setStreet(signupForm.getStreet());
-    userProfiles.setLatitude(signupForm.getLatitude());
-    userProfiles.setLongitude(signupForm.getLongitude());
-    userProfiles.setIntroduce(signupForm.getIntroduce());
-    userProfiles.setUrl(signupForm.getUrl());
-    userProfiles.setUrlName(signupForm.getUrlName());
-    return userProfiles;
-  }
+    public static UserProfiles create(Users users, SignupForm signupForm) {
+        UserProfiles userProfiles = new UserProfiles();
+        userProfiles.setUsers(users);
+        userProfiles.setNickname(signupForm.getNickname());
+        userProfiles.setCity(signupForm.getCity());
+        userProfiles.setState(signupForm.getState());
+        userProfiles.setStreet(signupForm.getStreet());
+        userProfiles.setLatitude(signupForm.getLatitude());
+        userProfiles.setLongitude(signupForm.getLongitude());
+        userProfiles.setIntroduce(signupForm.getIntroduce());
+        userProfiles.setUrl(signupForm.getUrl());
+        userProfiles.setUrlName(signupForm.getUrlName());
+        return userProfiles;
+    }
 }

--- a/src/main/java/com/example/dm/entity/Users.java
+++ b/src/main/java/com/example/dm/entity/Users.java
@@ -1,14 +1,7 @@
 package com.example.dm.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,49 +9,48 @@ import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Setter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Users extends BaseTimeEntity {
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  private Long id;
-  
-  @Column(length = 50, unique = true)
-  private String email;
-  private String password;
-  
-  private String provider;
-  private String providerId;
-  
-  @Column(length = 20)
-  private String role;
+public class Users extends DeletedEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
 
-  @ColumnDefault("true")
-  private boolean isVerificated;
-  @ColumnDefault("false")
-  private boolean isBlocked = false;
-  @ColumnDefault("false")
-  private boolean isInactivated = false;
-  @ColumnDefault("false")
-  private boolean isDeleted = false;
+    @Column(length = 50, unique = true)
+    private String email;
+    private String password;
 
-  private LocalDateTime deletedAt;
-  private LocalDateTime passwordChangedAt;
+    private String provider;
+    private String providerId;
 
-  @JsonIgnore
-  @OneToOne(mappedBy = "users", cascade = CascadeType.ALL)
-  private UserProfiles userProfiles;
+    @Column(length = 20)
+    private String role;
 
-  public static Users create(String email, String password, String provider, String providerId){
-    Users users = new Users();
-    users.setEmail(email);
-    users.setPassword(password);
-    users.setProvider(provider);
-    users.setProviderId(providerId);
-    users.setRole("USER");
-    return users;
-  }
+    @ColumnDefault("true")
+    private boolean isVerificated;
+    @ColumnDefault("false")
+    private boolean isBlocked = false;
+    @ColumnDefault("false")
+    private boolean isInactivated = false;
+
+    private LocalDateTime passwordChangedAt;
+
+    @JsonIgnore
+    @OneToOne(mappedBy = "users", cascade = CascadeType.ALL)
+    private UserProfiles userProfiles;
+
+    public static Users create(String email, String password, String provider, String providerId) {
+        Users users = new Users();
+        users.setEmail(email);
+        users.setPassword(password);
+        users.setProvider(provider);
+        users.setProviderId(providerId);
+        users.setRole("USER");
+        return users;
+    }
 }


### PR DESCRIPTION
## Add: DeletedEntity 추가

- _**5차 회의(9/7(목))에서 개발하기로 결정한 건입니다.**_
- `BaseTimeEntity` 처럼 `isDeleted`, `deletedAt` 컬럼만 따로 분리하여 `DeletedEntity` 생성
  - 상속(extends) 관계
    - 히스토리성 테이블x: `Users` < `DeletedEntity` < `BaseTimeEntity`
    - 히스토리성 테이블o: `Users` < `BaseTimeEntity`
- 공통 로깅 모듈 오타 수정: `requestId` -> `txid`