### PR TITLE
Update: categories 테이블 creator 컬럼명, 컬럼타입 변경 및 users 테이블과의 연관관계 추가

### DIFF
--- a/src/main/resources/db/migration/V2__alter_column_categories_creator.sql
+++ b/src/main/resources/db/migration/V2__alter_column_categories_creator.sql
@@ -1,0 +1,11 @@
+-- 1. 컬럼명 변경: creator -> creator_id
+ALTER TABLE categories
+    RENAME COLUMN creator TO creator_id;
+
+-- 2. 컬럼 타입 변경: varchar -> bigint
+ALTER TABLE categories
+    ALTER COLUMN creator_id TYPE BIGINT USING creator_id::BIGINT;
+
+-- 3. 참조키 생성: fk_categories_users
+ALTER TABLE categories
+    ADD CONSTRAINT fk_categories_users FOREIGN KEY (creator_id) REFERENCES users (id);


### PR DESCRIPTION
## Update: categories 테이블 creator 컬럼명, 컬럼타입 변경 및 users 테이블과의 연관관계 추가

### 연결된 이슈: #20 

- _**5차 회의(9/7(목))에서 개발하기로 결정한 건입니다.**_
- 기존 컬럼인 `creator` 는 카테고리 생성자 정보를 모두 담기엔 불명확한 컬럼명, 컬럼타입을 가지고 있음
- 명확한 카테고리 생성자 정보인 `admin users PK` 가 기록되도록 컬럼명, 컬럼 타입 수정 및 `users` 테이블과의 연관관계 추가
  - 컬럼명 변경: `creator` -> `creator_id`
  - 컬럼 타입 변경: `varchar` -> `bigint`
  - 연관관계 추가: `categories` -> `users`